### PR TITLE
Py3

### DIFF
--- a/payload/usr/local/sal/checkin_modules/salt_checkin_module.py
+++ b/payload/usr/local/sal/checkin_modules/salt_checkin_module.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/sal/Python.framework/Versions/3.8/bin/python3
 # Copyright 2019 Shea G. Craig
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,8 +21,7 @@ import re
 import subprocess
 import sys
 
-sys.path.insert(0, '/usr/local/sal')
-import utils
+import sal
 
 
 SALT_RETURNER_LOG = '/usr/local/sal/salt_returner_results.json'

--- a/payload/usr/local/sal/checkin_modules/salt_checkin_module.py
+++ b/payload/usr/local/sal/checkin_modules/salt_checkin_module.py
@@ -69,7 +69,7 @@ def process_salt_logs(pid):
     pattern = re.compile(LOG_PATTERN % pid, re.DOTALL)
     seen_matches = set()
     messages = []
-    for match in re.finditer(pattern, log):
+    for match in pattern.finditer(log):
         if match.groups() not in seen_matches:
             messages.append(match.groupdict())
             seen_matches.add(match.groups())

--- a/payload/usr/local/sal/checkin_modules/salt_checkin_module.py
+++ b/payload/usr/local/sal/checkin_modules/salt_checkin_module.py
@@ -17,6 +17,7 @@
 import datetime
 import json
 import os
+import pathlib
 import re
 import subprocess
 import sys
@@ -24,7 +25,7 @@ import sys
 import sal
 
 
-SALT_RETURNER_LOG = '/usr/local/sal/salt_returner_results.json'
+SALT_RETURNER_LOG = pathlib.Path('/usr/local/sal/salt_returner_results.json')
 
 LOG_PATTERN = (
     r'\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}\s*?'  # Date
@@ -37,10 +38,9 @@ LOG_PATTERN = (
 
 def main():
     results = {}
-    if os.path.exists(SALT_RETURNER_LOG):
+    if SALT_RETURNER_LOG.exists():
         try:
-            with open(SALT_RETURNER_LOG) as handle:
-                results = json.load(handle)
+            results = json.loads(SALT_RETURNER_LOG.read_text())
         except ValueError:
             pass
 
@@ -54,16 +54,16 @@ def main():
 
 def process_salt_logs(pid):
 
-    log_path = utils.pref('SALT_LOG_FILE', '/var/log/salt/minion')
-    if os.path.exists(log_path):
-        with open(log_path) as log_handle:
-            log = log_handle.read()
+    log_path = pathlib.Path(sal.pref('SALT_LOG_FILE', '/var/log/salt/minion'))
+    if log_path.exists():
+        log = log.read_text()
+    else:
+        log = ''
 
     # Example log line:
     # 2019-03-06 10:01:23,094 [root             :384 ][WARNING ][6972] <THE MESSAGE>
     # The message could be just everything until \n, or it could be
-    # multiple lines everything until \n, or it could be multiple lines
-    # terminated by a double \n\n.
+    # multiple lines terminated by a double \n\n.
 
     # Format the PID into the regex we've prepared, and compile it.
     pattern = re.compile(LOG_PATTERN % pid, re.DOTALL)

--- a/payload/usr/local/sal/checkin_modules/salt_checkin_module.py
+++ b/payload/usr/local/sal/checkin_modules/salt_checkin_module.py
@@ -49,7 +49,7 @@ def main():
     # output!
     results['messages'] = process_salt_logs(results['facts']['pid'])
 
-    utils.set_checkin_results('Salt', results)
+    sal.set_checkin_results('Salt', results)
 
 
 def process_salt_logs(pid):

--- a/payload/usr/local/sal/checkin_modules/salt_checkin_module.py
+++ b/payload/usr/local/sal/checkin_modules/salt_checkin_module.py
@@ -53,7 +53,7 @@ def process_salt_logs(pid):
 
     log_path = pathlib.Path(sal.pref('SALT_LOG_FILE', '/var/log/salt/minion'))
     if log_path.exists():
-        log = log.read_text()
+        log = log_path.read_text()
     else:
         log = ''
 

--- a/payload/usr/local/sal/checkin_modules/salt_checkin_module.py
+++ b/payload/usr/local/sal/checkin_modules/salt_checkin_module.py
@@ -14,13 +14,9 @@
 # limitations under the License.
 
 
-import datetime
 import json
-import os
 import pathlib
 import re
-import subprocess
-import sys
 
 import sal
 

--- a/payload/usr/local/sal/checkin_modules/salt_checkin_module.py
+++ b/payload/usr/local/sal/checkin_modules/salt_checkin_module.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 
+import datetime
 import json
 import pathlib
 import re
@@ -22,9 +23,9 @@ import sal
 
 
 SALT_RETURNER_LOG = pathlib.Path('/usr/local/sal/salt_returner_results.json')
-
+TIME_FORMAT = '%Y-%m-%d %H:%M:%S,%f'
 LOG_PATTERN = (
-    r'\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}\s*?'  # Date
+    r'(?P<date>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3})\s*?'  # Date
     r'\[.*?\]'  # Junk
     r'\[(?P<message_type>WARNING|ERROR)\s*\]'  # LogLevel
     r'\[%s]\s*'  # We format the PID into this %s
@@ -63,12 +64,25 @@ def process_salt_logs(pid):
 
     # Format the PID into the regex we've prepared, and compile it.
     pattern = re.compile(LOG_PATTERN % pid, re.DOTALL)
-    seen_matches = set()
+    # TODO: See below.
+    # seen_matches = set()
     messages = []
     for match in pattern.finditer(log):
-        if match.groups() not in seen_matches:
-            messages.append(match.groupdict())
-            seen_matches.add(match.groups())
+        message = match.groupdict()
+        # Grab the log datetime; this has no TZ offset, so we convert to
+        # UTC before serializing.
+        date = datetime.datetime.strptime(message['date'], TIME_FORMAT).astimezone(
+            datetime.timezone.utc).isoformat()
+        message['date'] = date
+        messages.append(message)
+        # TODO: This commented out code was in place to filter
+        # potentially massively redundant messages. Not sure we want
+        # this though, so leaving it in as an item of consideration for
+        # future releases.
+
+        # Filter out duplicate messages
+        # if message not in seen_matches:
+            # seen_matches.add(match.groups())
     return messages
 
 

--- a/payload/usr/local/sal/checkin_modules/salt_checkin_module.py
+++ b/payload/usr/local/sal/checkin_modules/salt_checkin_module.py
@@ -23,6 +23,9 @@ import sal
 
 
 SALT_RETURNER_LOG = pathlib.Path('/usr/local/sal/salt_returner_results.json')
+# This is the default time format; if you have configured your Salt
+# install to use something else, you'll need to edit the TIME_FORMAT and
+# LOG_PATTERN below to parse it correctly.
 TIME_FORMAT = '%Y-%m-%d %H:%M:%S,%f'
 LOG_PATTERN = (
     r'(?P<date>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3})\s*?'  # Date
@@ -41,7 +44,7 @@ def main():
         except ValueError:
             pass
 
-    # Oddly, the rawfile_json returner puts the PID into the top level
+    # Oddly, the returner puts the PID into the top level
     # dict. We grab it from Facts, since it's not in the normal log
     # output!
     results['messages'] = process_salt_logs(results['facts']['pid'])

--- a/sal_returner.py
+++ b/sal_returner.py
@@ -50,7 +50,6 @@ def __virtual__():
 def returner(ret):
     """"""
     results_path = os.path.join(SAL_PATH, 'salt_returner_results.json')
-
     results = {'managed_items': _process_managed_items(ret['return'])}
     results['extra_data'] = _process_extra_data(ret)
     results['facts'] = _flatten(_clean_grains(__grains__))


### PR DESCRIPTION
This PR updates the Sal v4 checkin code to use the sal-scripts py3 package and its embedded python framework.

Additionally, this update will now parse the naive log datetimes, add local TZ info, then convert to UTC and ship that with the messages submission. It will also no longer throw away identical messages. Please provide feedback if this is not working for you, as it's still somewhat speculative how best to do this.