### PR TITLE
Validating salt error 'item' has key 'comment' prior to JSON submission

### DIFF
--- a/sal_returner.py
+++ b/sal_returner.py
@@ -100,8 +100,9 @@ def _process_managed_items(items):
 
         # Add a message if the state failed.
         if not item['result']:
-            messages.append(
-                {'text': item['comment'], 'message_type': 'ERROR', 'date': managed_time})
+            if item['comment']:
+                messages.append(
+                    {'text': item['comment'], 'message_type': 'ERROR', 'date': managed_time})
 
         item['args'] = args
         if item.get('changes'):

--- a/sal_returner.py
+++ b/sal_returner.py
@@ -99,10 +99,9 @@ def _process_managed_items(items):
         item.pop('start_time')
 
         # Add a message if the state failed.
-        if not item['result']:
-            if item['comment']:
-                messages.append(
-                    {'text': item['comment'], 'message_type': 'ERROR', 'date': managed_time})
+        if not item['result'] and item['comment']:
+            messages.append(
+                {'text': item['comment'], 'message_type': 'ERROR', 'date': managed_time})
 
         item['args'] = args
         if item.get('changes'):


### PR DESCRIPTION
Ran into an error in our env where some salt errors being picked up by the Sal returner didn't have a `comment` key - this was submitting blank messages and crashing the Messages plugin in Sal when it tried to render them:

```
NoReverseMatch at /load_plugin/Messages/all/0/
Reverse for 'machine_list' with arguments '(Messages, '', 'all', 0)' not found. 1 pattern(s) tried: ['list/(?P<plugin_name>[^/]+)/(?P<data>[^/]+)/(?P<group_type>[^/]+)/(?P<group_id>[0-9]+)/$']
```

PR validates that the message items that are being submitted to salt returner results have valid key `comment` prior to their being appended to the JSON output.